### PR TITLE
Draft : Make Template.template_file read-only on edition

### DIFF
--- a/template_model/admin.py
+++ b/template_model/admin.py
@@ -7,6 +7,13 @@ from .forms import TemplateForm
 class TemplateAdmin(admin.ModelAdmin):
     form = TemplateForm
     list_display = ('name', 'added', 'updated')
+    readonly_fields = ('template_file',)
 
+    def get_readonly_fields(self, request, obj=None):
+        # Allows to specify the template file at creation, but disable it on change forms.
+        if obj:
+            return self.readonly_fields
+        else:
+            return []
 
 admin.site.register(Template, TemplateAdmin)

--- a/template_model/forms.py
+++ b/template_model/forms.py
@@ -5,7 +5,7 @@ from .models import Template
 
 
 class TemplateForm(forms.ModelForm):
-    template_file = forms.FileField(required=False, allow_empty_file=True)
+    #template_file = forms.FileField(required=False, allow_empty_file=True)
     content = forms.CharField(widget=forms.Textarea, required=False)
 
     class Meta:


### PR DESCRIPTION
However you can still specify the template at creation.
This commit will allow to automate upgrading template files managed by
Makina corpus.